### PR TITLE
Add redirect from root to home

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"tasks": {
 		"test": "pnpm check",
-		"launch": "pnpm dev",
+		"launch": "pnpm frontend:dev",
 		"build": "pnpm i"
 	}
 }

--- a/packages/frontend/src/routeTree.gen.ts
+++ b/packages/frontend/src/routeTree.gen.ts
@@ -13,6 +13,7 @@
 import { Route as rootRoute } from './routes/__root'
 import { Route as HomeImport } from './routes/home'
 import { Route as AboutImport } from './routes/about'
+import { Route as IndexImport } from './routes/index'
 
 // Create/Update Routes
 
@@ -26,10 +27,22 @@ const AboutRoute = AboutImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const IndexRoute = IndexImport.update({
+  path: '/',
+  getParentRoute: () => rootRoute,
+} as any)
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
     '/about': {
       id: '/about'
       path: '/about'
@@ -50,36 +63,41 @@ declare module '@tanstack/react-router' {
 // Create and export the route tree
 
 export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/home': typeof HomeRoute
 }
 
 export interface FileRoutesByTo {
+  '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/home': typeof HomeRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
+  '/': typeof IndexRoute
   '/about': typeof AboutRoute
   '/home': typeof HomeRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/about' | '/home'
+  fullPaths: '/' | '/about' | '/home'
   fileRoutesByTo: FileRoutesByTo
-  to: '/about' | '/home'
-  id: '__root__' | '/about' | '/home'
+  to: '/' | '/about' | '/home'
+  id: '__root__' | '/' | '/about' | '/home'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
   HomeRoute: typeof HomeRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
   HomeRoute: HomeRoute,
 }
@@ -96,9 +114,13 @@ export const routeTree = rootRoute
     "__root__": {
       "filePath": "__root.tsx",
       "children": [
+        "/",
         "/about",
         "/home"
       ]
+    },
+    "/": {
+      "filePath": "index.tsx"
     },
     "/about": {
       "filePath": "about.tsx"

--- a/packages/frontend/src/routes/index.tsx
+++ b/packages/frontend/src/routes/index.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/")({
+	loader: async () => {
+		return redirect({ to: "/home" });
+	},
+});


### PR DESCRIPTION
Fixes #24

Add redirection from `/` to `/home` in the frontend.

* **Route Configuration**
  - Add `index.tsx` file to define a route for `/` that redirects to `/home` using `redirect` from `@tanstack/react-router`.
* **Route Tree Update**
  - Modify `routeTree.gen.ts` to include the new route for `/` in the `routeTree`.
* **Devcontainer Task Update**
  - Change the `launch` task in `.devcontainer.json` to use `pnpm frontend:dev` instead of `pnpm dev`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yamatatsu/play-github-copilot-workspace/issues/24?shareId=2bc53bc9-947b-4e83-9b41-db53b4ec8fe3).