### PR TITLE
Add GET /todos API endpoint and display TODOs as cards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build project
+        run: pnpm build
+
       - name: Run Biome check
         run: pnpm check
-
-      - name: Build project
-        run: pnpm build:frontend

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"dev": "pnpm run '/dev:.*/'",
 		"dev:frontend": "pnpm --filter frontend dev",
 		"dev:backend": "pnpm --filter backend dev",
-		"build:frontend": "pnpm --filter frontend build",
+		"build": "pnpm -r build",
 		"prisma": "pnpm --filter backend exec prisma",
 		"lint": "biome check .",
 		"type-check": "pnpm run -r type-check",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"dev:frontend": "pnpm --filter frontend dev",
 		"dev:backend": "pnpm --filter backend dev",
 		"build:frontend": "pnpm --filter frontend build",
+		"prisma": "pnpm --filter backend exec prisma",
 		"lint": "biome check .",
 		"type-check": "pnpm run -r type-check",
 		"test": "pnpm -r test:ci",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,6 +6,7 @@
 	"types": "dist/app.d.ts",
 	"scripts": {
 		"test": "dotenvx run -- jest --watch",
+		"test:ci": "dotenvx run -- jest",
 		"type-check": "tsc --noEmit",
 		"dev": "dotenvx run -- tsx watch src/index.ts",
 		"start": "dotenvx run -- tsx src/index.ts",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,8 +6,8 @@
 	"types": "src/app.ts",
 	"scripts": {
 		"test": "dotenvx run -- jest --watch",
-		"dev": "tsx watch src/index.ts",
-		"start": "tsx src/index.ts"
+		"dev": "dotenvx run -- tsx watch src/index.ts",
+		"start": "dotenvx run -- tsx src/index.ts"
 	},
 	"dependencies": {
 		"@hono/node-server": "^1.13.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -3,17 +3,20 @@
 	"type": "module",
 	"version": "1.0.0",
 	"description": "",
-	"types": "src/app.ts",
+	"types": "dist/app.d.ts",
 	"scripts": {
 		"test": "dotenvx run -- jest --watch",
+		"type-check": "tsc --noEmit",
 		"dev": "dotenvx run -- tsx watch src/index.ts",
-		"start": "dotenvx run -- tsx src/index.ts"
+		"start": "dotenvx run -- tsx src/index.ts",
+		"build": "rm -rf dist && tsc --project ./tsconfig.hc.json"
 	},
 	"dependencies": {
 		"@hono/node-server": "^1.13.2",
 		"@hono/swagger-ui": "^0.4.1",
 		"@hono/zod-openapi": "^0.16.4",
 		"@prisma/client": "5.21.1",
+		"@types/node": "22.7.9",
 		"hono": "^4.6.5",
 		"jose": "^5.9.6",
 		"tsx": "^4.19.1",

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -5,6 +5,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import root from "./routes/root";
 import todosDelete from "./routes/todos/delete";
 import todosPost from "./routes/todos/post";
+import todosList from "./routes/todos/list";
 
 const _app = new OpenAPIHono({
 	defaultHook: (result, c) => {
@@ -21,6 +22,7 @@ export const app = _app
 	.route("/", root)
 	.route("/", todosDelete)
 	.route("/", todosPost)
+	.route("/", todosList)
 	.doc("/doc", {
 		openapi: "3.0.0",
 		info: { version: "1.0.0", title: "My API" },

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -2,10 +2,11 @@ import bearerAuth from "@/middleware/bearerAuth";
 import cors from "@/middleware/cors";
 import { swaggerUI } from "@hono/swagger-ui";
 import { OpenAPIHono } from "@hono/zod-openapi";
+import { logger } from "hono/logger";
 import root from "./routes/root";
 import todosDelete from "./routes/todos/delete";
-import todosPost from "./routes/todos/post";
 import todosList from "./routes/todos/list";
+import todosPost from "./routes/todos/post";
 
 const _app = new OpenAPIHono({
 	defaultHook: (result, c) => {
@@ -15,6 +16,7 @@ const _app = new OpenAPIHono({
 	},
 });
 
+_app.use("/*", logger());
 _app.use("/*", cors);
 _app.use("/*", bearerAuth);
 

--- a/packages/backend/src/routes/_shared/schema.ts
+++ b/packages/backend/src/routes/_shared/schema.ts
@@ -12,5 +12,11 @@ export const todoSchema = z
 		title: z.string().openapi({
 			example: "Buy milk",
 		}),
+		content: z.string().openapi({
+			example: "Buy milk",
+		}),
+		done: z.boolean().openapi({
+			example: false,
+		}),
 	})
 	.openapi("TODO");

--- a/packages/backend/src/routes/todos/list.test.ts
+++ b/packages/backend/src/routes/todos/list.test.ts
@@ -1,0 +1,21 @@
+import { prisma } from "@/db";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { testClient } from "hono/testing";
+import route from "./list";
+
+const app = new OpenAPIHono().route("/", route);
+const client = testClient(app);
+
+test("response when 200", async () => {
+	const todos = [
+		{ id: 1, title: "Test TODO 1", content: "Content 1", done: false, createdBy: "user1", createdAt: new Date(), updatedAt: new Date() },
+		{ id: 2, title: "Test TODO 2", content: "Content 2", done: false, createdBy: "user2", createdAt: new Date(), updatedAt: new Date() },
+	];
+
+	prisma
+
+	const res = await client.todos.$get();
+
+	expect(res.status).toBe(200);
+	expect(await res.json()).toEqual(todos);
+});

--- a/packages/backend/src/routes/todos/list.test.ts
+++ b/packages/backend/src/routes/todos/list.test.ts
@@ -8,14 +8,43 @@ const client = testClient(app);
 
 test("response when 200", async () => {
 	const todos = [
-		{ id: 1, title: "Test TODO 1", content: "Content 1", done: false, createdBy: "user1", createdAt: new Date(), updatedAt: new Date() },
-		{ id: 2, title: "Test TODO 2", content: "Content 2", done: false, createdBy: "user2", createdAt: new Date(), updatedAt: new Date() },
+		{
+			id: 1,
+			title: "Test TODO 1",
+			content: "Content 1",
+			done: false,
+			createdBy: "user1",
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		},
+		{
+			id: 2,
+			title: "Test TODO 2",
+			content: "Content 2",
+			done: false,
+			createdBy: "user2",
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		},
 	];
 
-	prisma
+	await prisma.todo.createMany({
+		data: todos,
+	});
 
-	const res = await client.todos.$get();
+	const res = await client.todos.$get({ header: { authorization: "" } });
 
 	expect(res.status).toBe(200);
-	expect(await res.json()).toEqual(todos);
+	expect(await res.json()).toEqual([
+		{
+			...todos[0],
+			createdAt: todos[0].createdAt.toISOString(),
+			updatedAt: todos[0].updatedAt.toISOString(),
+		},
+		{
+			...todos[1],
+			createdAt: todos[1].createdAt.toISOString(),
+			updatedAt: todos[1].updatedAt.toISOString(),
+		},
+	]);
 });

--- a/packages/backend/src/routes/todos/list.ts
+++ b/packages/backend/src/routes/todos/list.ts
@@ -1,0 +1,31 @@
+import { prisma } from "@/db";
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import { todoSchema } from "../_shared/schema";
+
+export default new OpenAPIHono().openapi(
+	createRoute({
+		method: "get",
+		path: "/todos",
+		summary: "Fetch TODOs",
+		tags: ["todos"],
+		request: {
+			headers: z.object({
+				authorization: z.string(),
+			}),
+		},
+		responses: {
+			200: {
+				description: "Success to fetch the todos",
+				content: {
+					"application/json": {
+						schema: z.array(todoSchema),
+					},
+				},
+			},
+		},
+	}),
+	async (c) => {
+		const todos = await prisma.todo.findMany();
+		return c.json(todos, 200);
+	},
+);

--- a/packages/backend/src/utils/env.ts
+++ b/packages/backend/src/utils/env.ts
@@ -1,8 +1,5 @@
-const { NODE_ENV, JWT_ISSUER, JWT_AUDIENCE } = process.env;
+const { JWT_ISSUER, JWT_AUDIENCE } = process.env;
 
-if (!NODE_ENV) {
-	throw new Error("NODE_ENV is required");
-}
 if (!JWT_ISSUER) {
 	throw new Error("JWT_ISSUER is required");
 }
@@ -10,4 +7,4 @@ if (!JWT_AUDIENCE) {
 	throw new Error("JWT_AUDIENCE is required");
 }
 
-export default { NODE_ENV, JWT_ISSUER, JWT_AUDIENCE };
+export default { JWT_ISSUER, JWT_AUDIENCE };

--- a/packages/backend/tsconfig.hc.json
+++ b/packages/backend/tsconfig.hc.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"emitDeclarationOnly": true,
+		"declaration": true,
+		"outDir": "./dist",
+		"baseUrl": "./src",
+		"paths": {
+			"@/*": ["./*"]
+		},
+		"strict": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/app.ts"]
+}

--- a/packages/frontend/src/routes/todos.tsx
+++ b/packages/frontend/src/routes/todos.tsx
@@ -4,7 +4,7 @@ import Cards from "@cloudscape-design/components/cards";
 import Header from "@cloudscape-design/components/header";
 import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { fetchAuthSession } from "aws-amplify/auth";
 import { apiClient } from "../api/apiClient";
@@ -13,52 +13,19 @@ export const Route = createFileRoute("/todos")({
 	component: Component,
 });
 
-const items = [
-	{
-		name: "Item 1",
-		alt: "First",
-		description: "This is the first item",
-		type: "1A",
-		size: "Small",
-	},
-	{
-		name: "Item 2",
-		alt: "Second",
-		description: "This is the second item",
-		type: "1B",
-		size: "Large",
-	},
-	{
-		name: "Item 3",
-		alt: "Third",
-		description: "This is the third item",
-		type: "1A",
-		size: "Large",
-	},
-	{
-		name: "Item 4",
-		alt: "Fourth",
-		description: "This is the fourth item",
-		type: "2A",
-		size: "Small",
-	},
-	{
-		name: "Item 5",
-		alt: "Fifth",
-		description: "This is the fifth item",
-		type: "2A",
-		size: "Large",
-	},
-	{
-		name: "Item 6",
-		alt: "Sixth",
-		description: "This is the sixth item",
-		type: "1A",
-		size: "Small",
-	},
-];
-
 function Component() {
+	const { data: todos, isLoading } = useQuery({
+		queryKey: ["api", "todos"],
+		queryFn: async () => {
+			const session = await fetchAuthSession();
+			const idToken = session.tokens?.idToken?.toString();
+
+			return apiClient.todos.$get({
+				header: { authorization: `Bearer ${idToken}` },
+			});
+		},
+	});
+
 	// TODO: refactor as moving to a shared file
 	const todoPostMutation = useMutation({
 		mutationFn: async () => {
@@ -94,39 +61,35 @@ function Component() {
 			cardDefinition={{
 				header: (item) => (
 					<Link href="#" fontSize="heading-m">
-						{item.name}
+						{item.title}
 					</Link>
 				),
 				sections: [
 					{
 						id: "description",
 						header: "Description",
-						content: (item) => item.description,
+						content: (item) => item.content,
 					},
 					{
-						id: "type",
-						header: "Type",
-						content: (item) => item.type,
-					},
-					{
-						id: "size",
-						header: "Size",
-						content: (item) => item.size,
+						id: "done",
+						header: "Done",
+						content: (item) => (item.done ? "Yes" : "No"),
 					},
 				],
 			}}
-			visibleSections={["description", "type", "size"]}
+			visibleSections={["description", "done"]}
 			cardsPerRow={[{ cards: 1 }, { minWidth: 500, cards: 2 }]}
 			loadingText="Loading resources"
 			empty={
-				<Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
-					<SpaceBetween size="m">
-						<b>No resources</b>
-						<Button>Create resource</Button>
-					</SpaceBetween>
-				</Box>
-			}
-			items={items}
+					<Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
+						<SpaceBetween size="m">
+							<b>No resources</b>
+							<Button>Create resource</Button>
+						</SpaceBetween>
+					</Box>
+				}
+			items={todos || []}
+			loading={isLoading}
 		/>
 	);
 }

--- a/packages/frontend/src/routes/todos.tsx
+++ b/packages/frontend/src/routes/todos.tsx
@@ -2,7 +2,6 @@ import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Cards from "@cloudscape-design/components/cards";
 import Header from "@cloudscape-design/components/header";
-import Link from "@cloudscape-design/components/link";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
@@ -19,10 +18,10 @@ function Component() {
 		queryFn: async () => {
 			const session = await fetchAuthSession();
 			const idToken = session.tokens?.idToken?.toString();
-
-			return apiClient.todos.$get({
+			const res = await apiClient.todos.$get({
 				header: { authorization: `Bearer ${idToken}` },
 			});
+			return res.json();
 		},
 	});
 
@@ -32,11 +31,18 @@ function Component() {
 			const session = await fetchAuthSession();
 			const idToken = session.tokens?.idToken?.toString();
 
-			return apiClient.todos.$post({
+			const res = await apiClient.todos.$post({
 				// TODO: set title from input
-				json: { title: "" },
+				json: { title: "Test Task" },
 				header: { authorization: `Bearer ${idToken}` },
 			});
+
+			if (res.status === 400) {
+				const { message } = await res.json();
+				throw new Error(message);
+			}
+
+			return res.json();
 		},
 	});
 
@@ -59,11 +65,7 @@ function Component() {
 				</Header>
 			}
 			cardDefinition={{
-				header: (item) => (
-					<Link href="#" fontSize="heading-m">
-						{item.title}
-					</Link>
-				),
+				header: (item) => item.title,
 				sections: [
 					{
 						id: "description",
@@ -77,19 +79,18 @@ function Component() {
 					},
 				],
 			}}
-			visibleSections={["description", "done"]}
-			cardsPerRow={[{ cards: 1 }, { minWidth: 500, cards: 2 }]}
-			loadingText="Loading resources"
+			cardsPerRow={[{ cards: 1 }]}
 			empty={
-					<Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
-						<SpaceBetween size="m">
-							<b>No resources</b>
-							<Button>Create resource</Button>
-						</SpaceBetween>
-					</Box>
-				}
+				<Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
+					<SpaceBetween size="m">
+						<b>No resources</b>
+						<Button>Create resource</Button>
+					</SpaceBetween>
+				</Box>
+			}
 			items={todos || []}
 			loading={isLoading}
+			loadingText="Loading resources"
 		/>
 	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@prisma/client':
         specifier: 5.21.1
         version: 5.21.1(prisma@5.21.1)
+      '@types/node':
+        specifier: 22.7.9
+        version: 22.7.9
       hono:
         specifier: ^4.6.5
         version: 4.6.6


### PR DESCRIPTION
close #56

Implement a new `GET /todos` API endpoint and update the frontend to fetch and display TODOs as cards.

* **Backend Changes:**
  - Add `packages/backend/src/routes/todos/list.ts` to implement `GET /todos` API endpoint using `prisma.todo.findMany`.
  - Modify `packages/backend/src/app.ts` to import and add the new `todosList` route.
  - Add tests in `packages/backend/src/routes/todos/list.test.ts` to verify the `GET /todos` API endpoint.

* **Frontend Changes:**
  - Update `packages/frontend/src/routes/todos.tsx` to fetch TODOs from the backend using `apiClient.todos.$get`.
  - Display the fetched TODOs as cards, replacing the hardcoded items.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yamatatsu/play-github-copilot-workspace/issues/56?shareId=61b51625-d59d-4727-bc33-b61c539b1799).