### PR TITLE
Refetch TODO list on successful creation

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
 		"type-check": "tsc --noEmit",
 		"dev": "dotenvx run -- tsx watch src/index.ts",
 		"start": "dotenvx run -- tsx src/index.ts",
-		"build": "rm -rf dist && tsc --project ./tsconfig.hc.json"
+		"build": "rm -rf dist && prisma generate && tsc --project ./tsconfig.hc.json"
 	},
 	"dependencies": {
 		"@hono/node-server": "^1.13.2",

--- a/packages/frontend/src/routes/todos.tsx
+++ b/packages/frontend/src/routes/todos.tsx
@@ -3,7 +3,7 @@ import Button from "@cloudscape-design/components/button";
 import Cards from "@cloudscape-design/components/cards";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { fetchAuthSession } from "aws-amplify/auth";
 import { apiClient } from "../api/apiClient";
@@ -13,6 +13,8 @@ export const Route = createFileRoute("/todos")({
 });
 
 function Component() {
+	const queryClient = useQueryClient();
+
 	const { data: todos, isLoading } = useQuery({
 		queryKey: ["api", "todos"],
 		queryFn: async () => {
@@ -43,6 +45,9 @@ function Component() {
 			}
 
 			return res.json();
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries(["api", "todos"]);
 		},
 	});
 

--- a/packages/frontend/src/routes/todos.tsx
+++ b/packages/frontend/src/routes/todos.tsx
@@ -47,7 +47,7 @@ function Component() {
 			return res.json();
 		},
 		onSuccess: () => {
-			queryClient.invalidateQueries(["api", "todos"]);
+			queryClient.invalidateQueries({ queryKey: ["api", "todos"] });
 		},
 	});
 


### PR DESCRIPTION
Fixes #66

Add refetching of TODO list upon successful creation of a new TODO.

* Import `useQueryClient` from `@tanstack/react-query` in `packages/frontend/src/routes/todos.tsx`.
* Add `queryClient` to `useMutation` hook to enable refetching.
* Add `onSuccess` callback to `useMutation` hook to refetch TODO list.
* Update `onClick` handler to include `onSuccess` callback.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yamatatsu/play-github-copilot-workspace/issues/66?shareId=09d4c4ef-15de-410e-9de8-0104657cc8f6).