### PR TITLE
feat(frontend): Use Table instead of Cards

### DIFF
--- a/packages/frontend/src/routes/todos.tsx
+++ b/packages/frontend/src/routes/todos.tsx
@@ -1,8 +1,8 @@
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
-import Cards from "@cloudscape-design/components/cards";
 import Header from "@cloudscape-design/components/header";
 import SpaceBetween from "@cloudscape-design/components/space-between";
+import Table from "@cloudscape-design/components/table";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { fetchAuthSession } from "aws-amplify/auth";
@@ -52,50 +52,51 @@ function Component() {
 	});
 
 	return (
-		<Cards
-			header={
-				<Header
-					actions={
-						<Button
-							variant="primary"
-							onClick={() => {
-								todoPostMutation.mutate();
-							}}
-						>
-							Create New TODO
-						</Button>
-					}
-				>
-					TODOs
-				</Header>
-			}
-			cardDefinition={{
-				header: (item) => item.title,
-				sections: [
+			<Table
+				columnDefinitions={[
+					{
+						id: "title",
+						header: "Title",
+						cell: (item) => item.title,
+					},
 					{
 						id: "description",
 						header: "Description",
-						content: (item) => item.content,
+						cell: (item) => item.content,
 					},
 					{
 						id: "done",
 						header: "Done",
-						content: (item) => (item.done ? "Yes" : "No"),
+						cell: (item) => (item.done ? "Yes" : "No"),
 					},
-				],
-			}}
-			cardsPerRow={[{ cards: 1 }]}
-			empty={
-				<Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
-					<SpaceBetween size="m">
-						<b>No resources</b>
-						<Button>Create resource</Button>
-					</SpaceBetween>
-				</Box>
-			}
-			items={todos || []}
-			loading={isLoading}
-			loadingText="Loading resources"
-		/>
+				]}
+				items={todos || []}
+				loading={isLoading}
+				loadingText="Loading resources"
+				header={
+					<Header
+						actions={
+							<Button
+								variant="primary"
+								onClick={() => {
+									todoPostMutation.mutate();
+								}}
+							>
+								Create New TODO
+							</Button>
+						}
+					>
+						TODOs
+					</Header>
+				}
+				empty={
+					<Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
+						<SpaceBetween size="m">
+							<b>No resources</b>
+							<Button>Create resource</Button>
+						</SpaceBetween>
+					</Box>
+				}
+			/>
 	);
 }

--- a/packages/frontend/src/routes/todos.tsx
+++ b/packages/frontend/src/routes/todos.tsx
@@ -52,51 +52,51 @@ function Component() {
 	});
 
 	return (
-			<Table
-				columnDefinitions={[
-					{
-						id: "title",
-						header: "Title",
-						cell: (item) => item.title,
-					},
-					{
-						id: "description",
-						header: "Description",
-						cell: (item) => item.content,
-					},
-					{
-						id: "done",
-						header: "Done",
-						cell: (item) => (item.done ? "Yes" : "No"),
-					},
-				]}
-				items={todos || []}
-				loading={isLoading}
-				loadingText="Loading resources"
-				header={
-					<Header
-						actions={
-							<Button
-								variant="primary"
-								onClick={() => {
-									todoPostMutation.mutate();
-								}}
-							>
-								Create New TODO
-							</Button>
-						}
-					>
-						TODOs
-					</Header>
-				}
-				empty={
-					<Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
-						<SpaceBetween size="m">
-							<b>No resources</b>
-							<Button>Create resource</Button>
-						</SpaceBetween>
-					</Box>
-				}
-			/>
+		<Table
+			columnDefinitions={[
+				{
+					id: "title",
+					header: "Title",
+					cell: (item) => item.title,
+				},
+				{
+					id: "description",
+					header: "Description",
+					cell: (item) => item.content,
+				},
+				{
+					id: "done",
+					header: "Done",
+					cell: (item) => (item.done ? "Yes" : "No"),
+				},
+			]}
+			items={todos || []}
+			loading={isLoading}
+			loadingText="Loading resources"
+			header={
+				<Header
+					actions={
+						<Button
+							variant="primary"
+							onClick={() => {
+								todoPostMutation.mutate();
+							}}
+						>
+							Create New TODO
+						</Button>
+					}
+				>
+					TODOs
+				</Header>
+			}
+			empty={
+				<Box margin={{ vertical: "xs" }} textAlign="center" color="inherit">
+					<SpaceBetween size="m">
+						<b>No resources</b>
+						<Button>Create resource</Button>
+					</SpaceBetween>
+				</Box>
+			}
+		/>
 	);
 }


### PR DESCRIPTION
Fixes #70

Replace the `Cards` component with the `Table` component in the `packages/frontend/src/routes/todos.tsx` file.

* Import the `Table` component from `@cloudscape-design/components/table`.
* Replace the `Cards` component with the `Table` component in the return statement.
* Configure the `Table` component to display columns for title, description, and done status.
* Update the header and empty state of the `Table` component to match the previous `Cards` component configuration.
* Ensure the `Table` component uses the same data source and loading state as the previous `Cards` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yamatatsu/play-github-copilot-workspace/issues/70?shareId=30f81be2-a678-4933-8b50-c0b147b84e2b).