### PR TITLE
feat(frontend): use modal for TODO creation

### DIFF
--- a/packages/frontend/src/routes/todos.tsx
+++ b/packages/frontend/src/routes/todos.tsx
@@ -1,10 +1,10 @@
 import Box from "@cloudscape-design/components/box";
 import Button from "@cloudscape-design/components/button";
 import Header from "@cloudscape-design/components/header";
+import Input from "@cloudscape-design/components/input";
+import Modal from "@cloudscape-design/components/modal";
 import SpaceBetween from "@cloudscape-design/components/space-between";
 import Table from "@cloudscape-design/components/table";
-import Modal from "@cloudscape-design/components/modal";
-import Input from "@cloudscape-design/components/input";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { fetchAuthSession } from "aws-amplify/auth";
@@ -155,10 +155,7 @@ function Component() {
 				header="Create TODO"
 				footer={
 					<SpaceBetween direction="horizontal" size="xs">
-						<Button
-							variant="link"
-							onClick={() => setIsModalVisible(false)}
-						>
+						<Button variant="link" onClick={() => setIsModalVisible(false)}>
 							Cancel
 						</Button>
 						<Button


### PR DESCRIPTION
Fixes #73

Implement modal for TODO creation in `packages/frontend/src/routes/todos.tsx`.

* **Import Modal Component**
  - Import `Modal` and `Input` components from `@cloudscape-design/components`.

* **State Management**
  - Add state to manage modal visibility and new TODO title.

* **Button to Open Modal**
  - Update the "create" button to open the modal.

* **Modal Implementation**
  - Add a modal with a form for entering TODO details.
  - Add a submit button in the modal to trigger `todoPostMutation`.

* **Form Submission**
  - Update form submission to trigger `todoPostMutation` with the new TODO title.
  - Reset modal visibility and new TODO title state on successful submission.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yamatatsu/play-github-copilot-workspace/issues/73?shareId=5aee5a7c-2107-4313-965d-04c1fd569921).