### PR TITLE
Add task done functionality

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -6,6 +6,7 @@ import root from "./routes/root";
 import taskDelete from "./routes/task-delete";
 import taskList from "./routes/task-list";
 import taskPost from "./routes/task-post";
+import taskPut from "./routes/task-put";
 
 export const app = new Hono()
 	// health check endpoint
@@ -16,6 +17,7 @@ export const app = new Hono()
 	.use("/*", cors)
 	.use("/*", bearerAuth)
 	// routes
-	.route("/", taskDelete)
+	.route("/", taskList)
 	.route("/", taskPost)
-	.route("/", taskList);
+	.route("/", taskPut)
+	.route("/", taskDelete);

--- a/packages/backend/src/routes/task-put.test.ts
+++ b/packages/backend/src/routes/task-put.test.ts
@@ -1,0 +1,71 @@
+import { prisma } from "@/db";
+import { Hono } from "hono";
+import { testClient } from "hono/testing";
+import route from "./task-put";
+
+const app = new Hono().route("/", route);
+const client = testClient(app);
+
+test("update task", async () => {
+	// GIVEN
+	const task = await prisma.task.create({
+		data: {
+			title: "Test Task",
+			content: "Test content",
+			createdBy: "test-user",
+		},
+	});
+
+	// WHEN
+	const res = await client.tasks[":taskId"].$put({
+		header: { authorization: "Bearer xxx" },
+		param: { taskId: task.id.toString() },
+		json: { done: true },
+	});
+
+	// THEN
+	expect(res.status).toBe(200);
+	expect(await res.json()).toEqual({
+		...task,
+		done: true,
+		createdAt: task.createdAt.toISOString(),
+		updatedAt: expect.any(String),
+	});
+
+	const updatedTask = await prisma.task.findUnique({
+		where: { id: task.id },
+	});
+	expect(updatedTask?.done).toBe(true);
+});
+
+test("invalid request body", async () => {
+	// GIVEN
+	const task = await prisma.task.create({
+		data: {
+			title: "Test Task",
+			content: "Test content",
+			createdBy: "test-user",
+		},
+	});
+
+	// WHEN
+	const res = await client.tasks[":taskId"].$put({
+		header: { authorization: "Bearer xxx" },
+		param: { taskId: task.id.toString() },
+		// @ts-expect-error
+		json: { done: "invalid" },
+	});
+
+	// THEN
+	expect(res.status).toBe(400);
+	expect(await res.json()).toEqual({
+		code: "schema_validation_failed",
+		message: "Bad Request",
+		errors: {
+			fieldErrors: {
+				done: ["Expected boolean, received string"],
+			},
+			formErrors: [],
+		},
+	});
+});

--- a/packages/frontend/src/api/index.tsx
+++ b/packages/frontend/src/api/index.tsx
@@ -32,6 +32,18 @@ export async function deleteTask(taskId: string) {
 	return res.json();
 }
 
+export async function updateTaskDone(taskId: string, done: boolean) {
+	const authHeader = await getAuthHeader();
+
+	const res = await apiClient.tasks[":taskId"].$put({
+		header: authHeader,
+		param: { taskId },
+		json: { done },
+	});
+
+	return res.json();
+}
+
 async function getAuthHeader() {
 	const session = await fetchAuthSession();
 	const idToken = session.tokens?.idToken?.toString();

--- a/packages/frontend/src/routes/tasks.tsx
+++ b/packages/frontend/src/routes/tasks.tsx
@@ -8,7 +8,7 @@ import Table from "@cloudscape-design/components/table";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
-import { deleteTask, listTasks, postTask } from "../api";
+import { deleteTask, listTasks, postTask, updateTaskDone } from "../api";
 
 export const Route = createFileRoute("/tasks")({
 	component: Component,
@@ -55,6 +55,15 @@ function Component() {
 		},
 	});
 
+	const taskUpdateDoneMutation = useMutation({
+		mutationFn: async ({ taskId, done }: { taskId: number; done: boolean }) => {
+			return updateTaskDone(taskId.toString(), done);
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["api", "tasks"] });
+		},
+	});
+
 	return (
 		<>
 			<Table
@@ -72,7 +81,18 @@ function Component() {
 					{
 						id: "done",
 						header: "Done",
-						cell: (item) => (item.done ? "Yes" : "No"),
+						cell: (item) => (
+							<input
+								type="checkbox"
+								checked={item.done}
+								onChange={(e) => {
+									taskUpdateDoneMutation.mutate({
+										taskId: item.id,
+										done: e.target.checked,
+									});
+								}}
+							/>
+						),
 					},
 				]}
 				items={tasks || []}


### PR DESCRIPTION
Fixes #82

Add functionality to mark tasks as done.

* Add a new API endpoint in `packages/backend/src/routes/task-put.ts` to update the `done` status of a task.
* Update `packages/backend/src/app.ts` to include the new `task-put` route.
* Add a new function `updateTaskDone` in `packages/frontend/src/api/index.tsx` to call the new API endpoint.
* Update `packages/frontend/src/routes/tasks.tsx` to include a checkbox to mark a task as `done` and call `updateTaskDone` on change.
* Add tests for the new API endpoint in `packages/backend/src/routes/task-put.test.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yamatatsu/play-github-copilot-workspace/pull/128?shareId=2e2ce9a8-a26e-4742-917d-c0193958620c).