### PR TITLE
Allow updating title and content fields

### DIFF
--- a/packages/backend/src/routes/task-put.test.ts
+++ b/packages/backend/src/routes/task-put.test.ts
@@ -71,6 +71,8 @@ test("invalid request body", async () => {
 		message: "Bad Request",
 		errors: {
 			fieldErrors: {
+				title: ["Required"],
+				content: ["Required"],
 				done: ["Expected boolean, received string"],
 			},
 			formErrors: [],

--- a/packages/backend/src/routes/task-put.test.ts
+++ b/packages/backend/src/routes/task-put.test.ts
@@ -20,13 +20,15 @@ test("update task", async () => {
 	const res = await client.tasks[":taskId"].$put({
 		header: { authorization: "Bearer xxx" },
 		param: { taskId: task.id.toString() },
-		json: { done: true },
+		json: { title: "Updated Task", content: "Updated content", done: true },
 	});
 
 	// THEN
 	expect(res.status).toBe(200);
 	expect(await res.json()).toEqual({
 		...task,
+		title: "Updated Task",
+		content: "Updated content",
 		done: true,
 		createdAt: task.createdAt.toISOString(),
 		updatedAt: expect.any(String),
@@ -35,7 +37,13 @@ test("update task", async () => {
 	const updatedTask = await prisma.task.findUnique({
 		where: { id: task.id },
 	});
-	expect(updatedTask?.done).toBe(true);
+	expect(updatedTask).toEqual(
+		expect.objectContaining({
+			title: "Updated Task",
+			content: "Updated content",
+			done: true,
+		}),
+	);
 });
 
 test("invalid request body", async () => {

--- a/packages/backend/src/routes/task-put.ts
+++ b/packages/backend/src/routes/task-put.ts
@@ -17,18 +17,22 @@ export default new Hono().put(
 	),
 	jsonValidator(
 		z.object({
+			title: z.string(),
+			content: z.string(),
 			done: z.boolean(),
 		}),
 	),
 	async (c) => {
 		const { taskId } = c.req.valid("param");
-		const { done } = c.req.valid("json");
+		const { title, content, done } = c.req.valid("json");
 
 		const task = await prisma.task.update({
 			where: {
 				id: taskId,
 			},
 			data: {
+				title,
+				content,
 				done,
 			},
 		});

--- a/packages/frontend/src/api/index.tsx
+++ b/packages/frontend/src/api/index.tsx
@@ -32,13 +32,18 @@ export async function deleteTask(taskId: string) {
 	return res.json();
 }
 
-export async function updateTaskDone(taskId: string, done: boolean) {
+export async function updateTask(
+	taskId: string,
+	title: string,
+	content: string,
+	done: boolean,
+) {
 	const authHeader = await getAuthHeader();
 
 	const res = await apiClient.tasks[":taskId"].$put({
 		header: authHeader,
 		param: { taskId },
-		json: { done },
+		json: { title, content, done },
 	});
 
 	return res.json();


### PR DESCRIPTION
Fixes #114

Enable updating `title` and `content` fields for tasks.

* **Backend Changes:**
  - Update `packages/backend/src/routes/task-put.ts` to allow updating `title` and `content` fields in addition to `done`.
  - Modify `jsonValidator` schema to include `title` and `content` fields.
  - Update `prisma.task.update` call to update `title`, `content`, and `done` fields.
  - Add a test case in `packages/backend/src/routes/task-put.test.ts` for updating `title` and `content` fields.
  - Modify the existing test case to include `title` and `content` in the `json` payload.

* **Frontend Changes:**
  - Add a new function `updateTask` in `packages/frontend/src/api/index.tsx` to update `title`, `content`, and `done` fields.
  - Modify `packages/frontend/src/routes/tasks.tsx` to include UI elements for updating `title` and `content` fields.
  - Replace `updateTaskDone` function with `updateTask` function in `taskUpdateMutation`.
  - Add input fields for `title` and `content` in the modal for creating and editing tasks.
  - Update the modal header to differentiate between creating and editing tasks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yamatatsu/play-github-copilot-workspace/pull/130?shareId=2a4a7a43-db4e-49d5-9a8b-51388977c9f6).