### PR TITLE
Filter tasks by user

### DIFF
--- a/packages/backend/src/routes/task-list.test.ts
+++ b/packages/backend/src/routes/task-list.test.ts
@@ -3,7 +3,12 @@ import { Hono } from "hono";
 import { testClient } from "hono/testing";
 import route from "./task-list";
 
-const app = new Hono().route("/", route);
+const app = new Hono()
+	.use("/*", (c, next) => {
+		c.set("jwtPayload", { sub: "user1" });
+		return next();
+	})
+	.route("/", route);
 const client = testClient(app);
 
 test("response when 200", async () => {
@@ -42,11 +47,6 @@ test("response when 200", async () => {
 			...tasks[0],
 			createdAt: tasks[0].createdAt.toISOString(),
 			updatedAt: tasks[0].updatedAt.toISOString(),
-		},
-		{
-			...tasks[1],
-			createdAt: tasks[1].createdAt.toISOString(),
-			updatedAt: tasks[1].updatedAt.toISOString(),
 		},
 	]);
 });

--- a/packages/backend/src/routes/task-list.ts
+++ b/packages/backend/src/routes/task-list.ts
@@ -6,7 +6,10 @@ export default new Hono().get(
 	"/tasks",
 	authorizationHeaderValidator(),
 	async (c) => {
-		const tasks = await prisma.task.findMany();
+		const { sub } = c.get("jwtPayload");
+		const tasks = await prisma.task.findMany({
+			where: { createdBy: sub },
+		});
 		return c.json(tasks, 200);
 	},
 );


### PR DESCRIPTION
Fixes #112

Filter tasks by the user who created them.

* Modify `packages/backend/src/routes/task-list.ts` to filter tasks by `createdBy` field using `sub` from JWT payload.
* Update `packages/backend/src/routes/task-list.test.ts` to test that only tasks created by the authenticated user are returned.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yamatatsu/play-github-copilot-workspace/pull/133?shareId=7a7aaba1-d814-4687-a2f3-e3c12efc9ec8).